### PR TITLE
Fix issue with multiple tabs being open simultaneously

### DIFF
--- a/js/subtitles.js
+++ b/js/subtitles.js
@@ -62,7 +62,7 @@ async function main() {
 
     // Continuous Listening
     spoken.listen.on.end(listen);
-    spoken.listen.on.error(listen);
+    spoken.listen.on.error(spoken.listen.on.end({}));
 
     // Search Giphy Image
     spoken.listen.on.partial(candidate);


### PR DESCRIPTION
If you open the app (subtitles.html) in multiple tabs the red microphone indicator (on the chrome tab) flashes rapidly, this is caused by the listen() function being called repeatedly which tries to enable speechRecognition and then fails, presumably because something else already has control of the microphone.

Unfortunately, there is no API in SpeechRecognizer that tells you if you can access the mic or not, you just need to try it and rely on the onError function giving you the unhelpful message of 'abort'.

Rather than try to handle every 'abort', this pull request addresses the looping call to listen() by not continually calling listen() whenever an error occurs - this also still allows you to listen and transcribe in multiple separate tabs simultaneously, in continuous mode.