### PR TITLE
Reverting change made under https://github.com/stephenlb/twitch-tv-obs-subtitles/pull/11

### DIFF
--- a/js/subtitles.js
+++ b/js/subtitles.js
@@ -62,7 +62,7 @@ async function main() {
 
     // Continuous Listening
     spoken.listen.on.end(listen);
-    spoken.listen.on.error(spoken.listen.on.end({}));
+    spoken.listen.on.error(listen);
 
     // Search Giphy Image
     spoken.listen.on.partial(candidate);


### PR DESCRIPTION
Leaving the page idle for a period of time will cause the microphone to disengage and the transcription to stop working.

The length of time taken for the microphone to stop listening is not consistent, it can be quite short or sometimes take more than a minute of silence but it will always stop.  This was caused by https://github.com/stephenlb/twitch-tv-obs-subtitles/pull/11, therefore reverting this regression.